### PR TITLE
Fix debug mode initialization for non-browser environments

### DIFF
--- a/src/game/debug.ts
+++ b/src/game/debug.ts
@@ -1,9 +1,12 @@
 // src/game/debug.ts
 
 // Debug mode can be activated by adding ?debug=true to the URL
-const urlParams = new URLSearchParams(window.location.search);
+const urlParams =
+  typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search)
+    : new URLSearchParams('');
 export const IS_DEBUG_MODE = urlParams.get('debug') === 'true';
 
-if (IS_DEBUG_MODE) {
+if (IS_DEBUG_MODE && typeof window !== 'undefined') {
   console.log('%c-- DEBUG MODE ON --', 'color: red; font-weight: bold;');
-} 
+}


### PR DESCRIPTION
## Summary
- make the debug mode helper safe to import in Node

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685aaf933bf4832f94d415f07df06496